### PR TITLE
Add validation and test for invalid category_id in scripts#show (#40)

### DIFF
--- a/rr-et/app/Category.php
+++ b/rr-et/app/Category.php
@@ -11,7 +11,12 @@ class Category extends Model
     {
         return $this->hasMany('App\Script');
     }
-    
+
+    public static function getAllCategoryId()
+    {
+        return Category::pluck('id');
+    }
+
     /**
      * The attributes that are mass assignable.
      *

--- a/rr-et/app/Http/Requests/CreateScript.php
+++ b/rr-et/app/Http/Requests/CreateScript.php
@@ -3,6 +3,8 @@
 namespace App\Http\Requests;
 
 use Illuminate\Foundation\Http\FormRequest;
+use App\Category;
+use Illuminate\Validation\Rule;
 
 class CreateScript extends FormRequest
 {
@@ -23,8 +25,10 @@ class CreateScript extends FormRequest
      */
     public function rules()
     {
+        $invaild_category_id = Category::getAllCategoryId();
+        $category_id_rule = Rule::in($invaild_category_id);
         return [
-            'category_id' => 'required',
+            'category_id' => 'required|'.$category_id_rule,
             'content' => 'required|max:100'
         ];
     }

--- a/rr-et/tests/Unit/ScriptTest.php
+++ b/rr-et/tests/Unit/ScriptTest.php
@@ -155,7 +155,7 @@ class ScriptTest extends TestCase
     {
         $data = [
             'content' => 'Linuxチョットデキル',
-            'category_id' => 5,
+            'category_id' => 1000,
         ];
         $request = new CreateScript();
         $rules = $request->rules();
@@ -164,8 +164,9 @@ class ScriptTest extends TestCase
 
         $result = $validator->passes();
         $this->assertFalse($result);
+
         $expectedFailed = [
-            'category_id' => [],
+            'category_id' => ['In' => [1,2,3,4],],
         ];
         $this->assertEquals($expectedFailed, $validator->failed());
     }


### PR DESCRIPTION
ネタ投稿で不正なカテゴリー入力を無効にするため